### PR TITLE
Optimize viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/
@@ -29,7 +29,7 @@ var/
 # Sphinx
 doc/_build
 
-# OS generated files 
+# OS generated files
 .DS_Store
 .DS_Store?
 .Trashes
@@ -45,4 +45,3 @@ Thumbs.db
 
 # Pypot record files
 *.record
-

--- a/simulator/index.html
+++ b/simulator/index.html
@@ -1,12 +1,28 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
+  <title>Poppy Ergo Jr - Viewer</title>
+  <style media="screen">
+    html, body {
+      width: 100vw;
+      height: 100vh;
+
+      margin: 0;
+      padding: 0;
+
+      overflow-x: hidden;
+    }
+
+    #container {
+      width: 100%;
+      height: 100%;
+    }
+
+    canvas { display: block; }
+  </style>
   <script src="js/config.js"></script>
   <script data-main="../main" src="js/require.js"></script>
-  <style media="screen">
-    html, body { margin: 0; }
-    canvas { width: 100%; height: 100%; }
-  </style>
 </head>
 <body>
   <div id="container"></div>

--- a/simulator/js/app/app.js
+++ b/simulator/js/app/app.js
@@ -1,14 +1,25 @@
-define( ["container", "three", "camera", "controls", "light", "renderer", "scene", "stater", "helpers", "ergojr", "octopus"],
-function ( container, THREE, camera, controls, light, renderer, scene, stater, _, ERGOJR, octopus) {
+define([
+  'container',
+  'three',
+  'camera',
+  'controls',
+  'light',
+  'renderer',
+  'scene',
+  'stater',
+  'helpers',
+  'ergojr',
+  'octopus'
+], function(container, THREE, camera, controls, light, renderer, scene, stater, _, ERGOJR, octopus) {
   var app = {
     ergo: undefined,
-    init: function () {
-      container.innerHTML = "";
-      container.appendChild( renderer.domElement );
-      container.appendChild( stater.domElement );
 
-      THREE.DefaultLoadingManager.onProgress = function ( item, loaded, total ) {
-        // console.log(item);
+    init: function() {
+      container.innerHTML = '';
+      container.appendChild(renderer.domElement);
+      container.appendChild(stater.domElement);
+
+      THREE.DefaultLoadingManager.onProgress = function(item, loaded, total) {
         if (loaded === total) {
           app.ergo = new ERGOJR.Robot();
           scene.add(app.ergo);
@@ -16,16 +27,19 @@ function ( container, THREE, camera, controls, light, renderer, scene, stater, _
         }
       };
     },
-    animate: function () {
+
+    animate: function() {
       app.render();
       window.requestAnimationFrame(app.animate);
     },
-    render: function () {
+
+    render: function() {
       stater.update();
       controls.update();
       octopus.update();
-      renderer.render( scene, camera );
+      renderer.render(scene, camera);
     }
   };
+
   return app;
-} );
+});

--- a/simulator/js/app/camera.js
+++ b/simulator/js/app/camera.js
@@ -1,17 +1,14 @@
-define( ["three"], function ( THREE ) {
+define([ 'three' ], function(THREE) {
 
-  var canvasWidth = window.innerWidth;
-  var canvasHeight = window.innerHeight;
-  var canvasRatio = canvasWidth / canvasHeight;
+  var canvasRatio = window.innerWidth / window.innerHeight;
+  var camera = new THREE.PerspectiveCamera(38, canvasRatio, 1, 10000);
 
-  var camera = new THREE.PerspectiveCamera( 38, canvasRatio, 1, 10000 );
-  camera.position.set(-200, 200, -500);
+  camera.position.set(-300, 300, -500);
 
-  window.addEventListener( 'resize', onWindowResize, false );
-  function onWindowResize(){
-      camera.aspect = window.innerWidth / window.innerHeight;
-      camera.updateProjectionMatrix();
-  }
+  window.addEventListener('resize', function() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+  }, false);
 
   return camera;
-} );
+});

--- a/simulator/js/app/container.js
+++ b/simulator/js/app/container.js
@@ -1,3 +1,3 @@
-define( [], function () {
-  return document.getElementById( 'container' );
-} );
+define([], function() {
+  return document.getElementById('container');
+});

--- a/simulator/js/app/controls.js
+++ b/simulator/js/app/controls.js
@@ -1,7 +1,7 @@
-define( ["three", "camera", "renderer"], function( THREE, camera, renderer ) {
+define([ 'three', 'camera', 'renderer' ], function(THREE, camera, renderer) {
+  var controls = new THREE.OrbitControls(camera , renderer.domElement);
 
-  var controls = new THREE.OrbitControls( camera , renderer.domElement );
   controls.damping = 0.2;
 
   return controls;
-} );
+});

--- a/simulator/js/app/gui.js
+++ b/simulator/js/app/gui.js
@@ -1,44 +1,42 @@
-define( ["dat"], function( dat ) {
+define([ 'dat' ], function(dat) {
 
   var gui = {};
 
   gui.gui = new dat.GUI();
 
   gui.guiData = {
-    M1: 0.0,
-    M2: 0.0,
-    M3: 0.0,
-    M4: 0.0,
-    M5: 0.0,
-    M6: 0.0,
+    m1: 0,
+    m2: 0,
+    m3: 0,
+    m4: 0,
+    m5: 0,
+    m6: 0,
 
     partColor: 0xFFFFFF,
 
     remoteStatus: false,
-    remoteIP: "127.0.0.1",
-    remotePORT: "8080",
+    remoteIP: '127.0.0.1',
+    remotePORT: '8080',
     remoteFrequency: 20,
-
   };
 
   gui.controller = {};
 
-  gui.controller.motors = gui.gui.addFolder("Motors angles");
-  gui.controller.motors.add( gui.guiData, "M1", -180.0, 180.0, 0.025).name("M1");
-  gui.controller.motors.add( gui.guiData, "M2", -180.0, 180.0, 0.025).name("M2");
-  gui.controller.motors.add( gui.guiData, "M3", -180.0, 180.0, 0.025).name("M3");
-  gui.controller.motors.add( gui.guiData, "M4", -180.0, 180.0, 0.025).name("M4");
-  gui.controller.motors.add( gui.guiData, "M5", -180.0, 180.0, 0.025).name("M5");
-  gui.controller.motors.add( gui.guiData, "M6", -180.0, 180.0, 0.025).name("M6");
+  gui.controller.motors = gui.gui.addFolder('Motors angles');
+  gui.controller.motors.add(gui.guiData, 'm1', -180, 180, 0.025).name('m1').listen();
+  gui.controller.motors.add(gui.guiData, 'm2', -180, 180, 0.025).name('m2').listen();
+  gui.controller.motors.add(gui.guiData, 'm3', -180, 180, 0.025).name('m3').listen();
+  gui.controller.motors.add(gui.guiData, 'm4', -180, 180, 0.025).name('m4').listen();
+  gui.controller.motors.add(gui.guiData, 'm5', -180, 180, 0.025).name('m5').listen();
+  gui.controller.motors.add(gui.guiData, 'm6', -180, 180, 0.025).name('m6').listen();
 
-  gui.controller.colorController = gui.gui.addColor( gui.guiData, "partColor").name("Color").listen();
+  gui.controller.colorController = gui.gui.addColor(gui.guiData, 'partColor').name('Color').listen();
 
-  gui.controller.remote = gui.gui.addFolder("Remote Control");
-  gui.controller.remote.add( gui.guiData, "remoteStatus").name("Enable");
-  gui.controller.remoteIP = gui.controller.remote.add( gui.guiData, "remoteIP").name("IP");
-  gui.controller.remotePORT = gui.controller.remote.add( gui.guiData, "remotePORT").name("PORT");
-  gui.controller.remoteFrequency = gui.controller.remote.add( gui.guiData, "remoteFrequency", 1, 25, 1).name("Frequency");
+  gui.controller.remote = gui.gui.addFolder('Remote Control');
+  gui.controller.remote.add(gui.guiData, 'remoteStatus').name('Enable');
+  gui.controller.remoteIP = gui.controller.remote.add(gui.guiData, 'remoteIP').name('IP');
+  gui.controller.remotePORT = gui.controller.remote.add(gui.guiData, 'remotePORT').name('PORT');
+  gui.controller.remoteFrequency = gui.controller.remote.add(gui.guiData, 'remoteFrequency', 1, 35, 1).name('Frequency');
 
   return gui;
-
 });

--- a/simulator/js/app/gui.js
+++ b/simulator/js/app/gui.js
@@ -37,7 +37,7 @@ define( ["dat"], function( dat ) {
   gui.controller.remote.add( gui.guiData, "remoteStatus").name("Enable");
   gui.controller.remoteIP = gui.controller.remote.add( gui.guiData, "remoteIP").name("IP");
   gui.controller.remotePORT = gui.controller.remote.add( gui.guiData, "remotePORT").name("PORT");
-  gui.controller.remoteFrequency = gui.controller.remote.add( gui.guiData, "remoteFrequency", 1, 50, 1).name("Frequency");
+  gui.controller.remoteFrequency = gui.controller.remote.add( gui.guiData, "remoteFrequency", 1, 25, 1).name("Frequency");
 
   return gui;
 

--- a/simulator/js/app/helpers.js
+++ b/simulator/js/app/helpers.js
@@ -1,7 +1,13 @@
-define( ["three", "scene", "coordinates"], function ( THREE, scene, Coordinates) {
+define([ 'three', 'scene', 'coordinates' ] , function(THREE, scene, Coordinates) {
 
-  // Coordinates.drawGround({size:10000}, scene);
-  Coordinates.drawGrid({size:10000,scale:0.01}, scene);
-  Coordinates.drawAllAxes({axisLength:200,axisRadius:1,axisTess:50}, scene);
+  Coordinates.drawGrid({
+    size: 10000,
+    scale: 0.01
+  }, scene);
 
-} );
+  Coordinates.drawAllAxes({
+    axisLength: 200,
+    axisRadius: 1,
+    axisTess: 50
+  }, scene);
+});

--- a/simulator/js/app/light.js
+++ b/simulator/js/app/light.js
@@ -1,15 +1,15 @@
-define( ["three", "scene"], function ( THREE, scene ) {
+define([ 'three', 'scene' ], function (THREE, scene) {
   var light = [];
 
-  light.push(new THREE.AmbientLight( 0x222222 ));
-  light.push(new THREE.DirectionalLight( 0xFFFFFF, 1.0 ));
-  light[1].position.set( 200, 400, 500 );
-  light.push(new THREE.DirectionalLight( 0xFFFFFF, 1.0 ));
-  light[2].position.set( -500, 250, -200 );
+  light.push(new THREE.AmbientLight(0x222222));
+  light.push(new THREE.DirectionalLight(0xFFFFFF, 1));
+  light[1].position.set(200, 400, 500);
+  light.push(new THREE.DirectionalLight(0xFFFFFF, 1));
+  light[2].position.set(-500, 250, -200);
 
-  for ( var l in light ) {
+  for (var l in light) {
     scene.add(light[l]);
   }
 
   return light;
-} );
+});

--- a/simulator/js/app/octopus.js
+++ b/simulator/js/app/octopus.js
@@ -1,26 +1,30 @@
-define( ["ergojr", "pypot", "gui"], function(ERGOJR, PYPOT, gui ) {
+define([ 'ergojr', 'pypot', 'gui' ], function(ERGOJR, PYPOT, gui) {
 
   var octopus = {};
+  var PI = Math.PI;
 
-  octopus.setErgo = function(ergo) { // I don't like this, but did not succeed in requiring "app" think more
+  // @TODO I don't like this, but did not succeed in requiring 'app'
+  //  think more
+  octopus.setErgo = function(ergo) {
     octopus.ergo = ergo;
   }
 
   // setting up callback on gui events
   gui.guiData.partColor = ERGOJR.printedPartsColor;
-  gui.controller.colorController.onChange( function(value) {
+
+  gui.controller.colorController.onChange(function(value) {
     octopus.ergo.setColor(new THREE.Color(gui.guiData.partColor));
   });
 
-  gui.controller.remoteIP.onChange( function(value) {
+  gui.controller.remoteIP.onChange(function(value) {
     PYPOT.IP = gui.guiData.remoteIP;
   });
 
-  gui.controller.remotePORT.onChange( function(value) {
+  gui.controller.remotePORT.onChange(function(value) {
     PYPOT.PORT = gui.guiData.remotePORT;
   });
 
-  gui.controller.remoteFrequency.onChange( function(value) {
+  gui.controller.remoteFrequency.onChange(function(value) {
     PYPOT.FREQ = gui.guiData.remoteFrequency;
     if (gui.guiData.remoteStatus) {
       PYPOT.stopPoll();
@@ -31,26 +35,24 @@ define( ["ergojr", "pypot", "gui"], function(ERGOJR, PYPOT, gui ) {
   octopus.update = function() {
     if (gui.guiData.remoteStatus) {
       PYPOT.startPoll();
-      octopus.ergo.S1.rotation.z = PYPOT.motors.M1 * Math.PI/180;
-      octopus.ergo.S2.rotation.z = PYPOT.motors.M2 * Math.PI/180;
-      octopus.ergo.S3.rotation.z = PYPOT.motors.M3 * Math.PI/180;
-      octopus.ergo.S4.rotation.z = PYPOT.motors.M4 * Math.PI/180 + Math.PI/2.0;
-      octopus.ergo.S5.rotation.z = PYPOT.motors.M5 * Math.PI/180;
-      octopus.ergo.S6.rotation.z = PYPOT.motors.M6 * Math.PI/180;
-    }
-    else{
+      octopus.ergo.S1.rotation.z = PYPOT.motors.m1 * PI / 180;
+      octopus.ergo.S2.rotation.z = PYPOT.motors.m2 * PI / 180;
+      octopus.ergo.S3.rotation.z = PYPOT.motors.m3 * PI / 180;
+      octopus.ergo.S4.rotation.z = PYPOT.motors.m4 * PI / 180 + PI / 2;
+      octopus.ergo.S5.rotation.z = PYPOT.motors.m5 * PI / 180;
+      octopus.ergo.S6.rotation.z = PYPOT.motors.m6 * PI / 180;
+    } else {
       PYPOT.stopPoll();
       if ( octopus.ergo !== undefined ) {
-        octopus.ergo.S1.rotation.z = gui.guiData.M1 * Math.PI/180;
-        octopus.ergo.S2.rotation.z = gui.guiData.M2 * Math.PI/180;
-        octopus.ergo.S3.rotation.z = gui.guiData.M3 * Math.PI/180;
-        octopus.ergo.S4.rotation.z = gui.guiData.M4 * Math.PI/180 + Math.PI/2.0;
-        octopus.ergo.S5.rotation.z = gui.guiData.M5 * Math.PI/180;
-        octopus.ergo.S6.rotation.z = gui.guiData.M6 * Math.PI/180;
+        octopus.ergo.S1.rotation.z = gui.guiData.m1 * PI / 180;
+        octopus.ergo.S2.rotation.z = gui.guiData.m2 * PI / 180;
+        octopus.ergo.S3.rotation.z = gui.guiData.m3 * PI / 180;
+        octopus.ergo.S4.rotation.z = gui.guiData.m4 * PI / 180 + PI / 2;
+        octopus.ergo.S5.rotation.z = gui.guiData.m5 * PI / 180;
+        octopus.ergo.S6.rotation.z = gui.guiData.m6 * PI / 180;
       }
     }
   }
 
-
   return octopus;
-} );
+});

--- a/simulator/js/app/renderer.js
+++ b/simulator/js/app/renderer.js
@@ -1,19 +1,17 @@
-define( ["three"], function ( THREE, container ) {
+define([ 'three', 'container' ], function(THREE, container) {
 
-  var canvasWidth = window.innerWidth;
-  var canvasHeight = window.innerHeight;
+  var canvasWidth = container.offsetWidth;
+  var canvasHeight = container.offsetHeight;
+  var renderer = new THREE.WebGLRenderer({ antialias: true });
 
-  var renderer = new THREE.WebGLRenderer( { antialias: true } );
   renderer.gammaInput = true;
   renderer.gammaOutput = true;
   renderer.setSize(canvasWidth, canvasHeight);
-  renderer.setClearColor( 0xAAAAAA, 1.0 );
+  renderer.setClearColor(0xAAAAAA, 1);
 
-  window.addEventListener( 'resize', onWindowResize, false );
-  function onWindowResize(){
-      renderer.setSize( window.innerWidth, window.innerHeight );
-  }
-
+  window.addEventListener('resize', function() {
+    renderer.setSize(container.offsetWidth, container.offsetHeight);
+  }, false);
 
   return renderer;
-} );
+});

--- a/simulator/js/app/scene.js
+++ b/simulator/js/app/scene.js
@@ -1,5 +1,8 @@
-define( ["three"], function ( THREE ) {
+define([ 'three' ], function(THREE) {
+
   var scene = new THREE.Scene();
-  scene.fog = new THREE.Fog( 0x808080, 2000, 4000 );
+
+  scene.fog = new THREE.Fog(0x808080, 2000, 4000);
+
   return scene;
-} );
+});

--- a/simulator/js/app/stater.js
+++ b/simulator/js/app/stater.js
@@ -1,9 +1,10 @@
-define( ["stats"], function ( Stats, container ) {
+define([ 'stats' ], function(Stats, container) {
 
   var stater = new Stats();
+
   stater.domElement.style.position = 'absolute';
   stater.domElement.style.top = '0px';
   stater.domElement.style.zIndex = 100;
-  
+
   return stater;
-} );
+});

--- a/simulator/js/config.js
+++ b/simulator/js/config.js
@@ -17,7 +17,7 @@ var require = {
     'coordinates': {exports: 'Coordinates'},
     'detector': { exports: 'Detector' },
     'stats': { exports: 'Stats' },
-    'dat': {exports: 'dat'},
+    'dat': {exports: 'dat'}
   },
   // Third party code lives in js/lib
   paths: {
@@ -36,6 +36,6 @@ var require = {
     coordinates: '../lib/Coordinates',
     detector: '../lib/Detector',
     stats: '../lib/stats.min',
-    dat: '../lib/dat.gui.min',
+    dat: '../lib/dat.gui.min'
   }
 };

--- a/simulator/js/ergo/STLLibrary.js
+++ b/simulator/js/ergo/STLLibrary.js
@@ -4,15 +4,15 @@ var STLLibrary = {};
 STLLibrary.geometry = []; // this stores the geometry associated with each stl file
 
 STLLibrary.add = function(file, key) {
-    // stlInfo must have two fields
-    // stlInfo.file specify the location of the stl file to be loaded
-    // stlInfo.key specify the key to recall when creating a three.js object 3D instance using the stl geometry
+  // stlInfo must have two fields
+  // stlInfo.file specify the location of the stl file to be loaded
+  // stlInfo.key specify the key to recall when creating a three.js object 3D instance using the stl geometry
 
-    console.log('Loading ' + file + ' as ' + key + ' ...');
+  console.log('Loading ' + file + ' as ' + key + ' ...');
 
-    var loader = new THREE.STLLoader();
-    loader.load(file, function ( stlGeometry ) {
-      STLLibrary.geometry[key] = stlGeometry;
-      console.log(key +  ' loaded');
-    });
-  }
+  var loader = new THREE.STLLoader();
+  loader.load(file, function(stlGeometry) {
+    STLLibrary.geometry[key] = stlGeometry;
+    console.log(key + ' loaded');
+  });
+}

--- a/simulator/js/ergo/XL320.js
+++ b/simulator/js/ergo/XL320.js
@@ -7,30 +7,30 @@ STLLibrary.add('js/ergo/stl/XL320_bottom_horn.stl', 'XL320_bottom_horn');
 var XL320 = {};
 
 // XL320 motor dimensions
-XL320.MotorWidth = 24.0; // this is 4 Ollospacing
-XL320.MotorHeight = 24.0; // this is 4 Ollospacing
-XL320.MotorLength = 36.0; // this is 6 Ollospacing
-XL320.MotorAxisOffset = 9.0;
+XL320.MotorWidth = 24; // this is 4 Ollospacing
+XL320.MotorHeight = 24; // this is 4 Ollospacing
+XL320.MotorLength = 36; // this is 6 Ollospacing
+XL320.MotorAxisOffset = 9;
 XL320.BackExtrudeDepth = XL320.MotorLength - 31.5;
 
 // Horn parameter
-XL320.HornTopDiameter = 18.0;
-XL320.HornBottomDiameter = 20.0;
+XL320.HornTopDiameter = 18;
+XL320.HornBottomDiameter = 20;
 
 // Materials
-XL320.BodyMaterial = new THREE.MeshLambertMaterial( { color: 0xAAAAAA } );
-XL320.HornTopMaterial = new THREE.MeshLambertMaterial( { color: 0x222222} );
-XL320.HornBottomMaterial = new THREE.MeshLambertMaterial( { color: 0xAAAAAA } );
+XL320.BodyMaterial = new THREE.MeshLambertMaterial({ color: 0xAAAAAA });
+XL320.HornTopMaterial = new THREE.MeshLambertMaterial({ color: 0x222222});
+XL320.HornBottomMaterial = new THREE.MeshLambertMaterial({ color: 0xAAAAAA });
 
 //
 XL320.Object3D = function() {
   THREE.Object3D.call(this);
 
-  var body = new THREE.Mesh( STLLibrary.geometry['XL320_box'], XL320.BodyMaterial);
+  var body = new THREE.Mesh(STLLibrary.geometry['XL320_box'], XL320.BodyMaterial);
   this.add(body);
 
-  var hornTop = new THREE.Mesh( STLLibrary.geometry['XL320_top_horn'], XL320.HornTopMaterial);
-  hornTop.position.z = XL320.MotorHeight/2.0 + OLLO.LayerThickness/2.0;
+  var hornTop = new THREE.Mesh(STLLibrary.geometry['XL320_top_horn'], XL320.HornTopMaterial);
+  hornTop.position.z = XL320.MotorHeight / 2 + OLLO.LayerThickness / 2;
   this.add(hornTop);
 }
 XL320.Object3D.prototype = Object.create(THREE.Object3D.prototype);
@@ -40,8 +40,8 @@ XL320.Object3D.prototype.constructor = XL320.Object3D;
 XL320.Object3DTwoHorns = function () {
   XL320.Object3D.call(this);
 
-  var hornBottom = new THREE.Mesh( STLLibrary.geometry['XL320_bottom_horn'], XL320.HornBottomMaterial);
-  hornBottom.position.z = - XL320.MotorHeight/2.0 - OLLO.LayerThickness/2.0;
+  var hornBottom = new THREE.Mesh(STLLibrary.geometry['XL320_bottom_horn'], XL320.HornBottomMaterial);
+  hornBottom.position.z = - XL320.MotorHeight / 2 - OLLO.LayerThickness / 2;
   this.add(hornBottom);
 }
 

--- a/simulator/js/ergo/ergojr.js
+++ b/simulator/js/ergo/ergojr.js
@@ -1,4 +1,3 @@
-
 // loading stl used
 STLLibrary.add('js/ergo/stl/base.stl', 'base');
 STLLibrary.add('js/ergo/stl/shift_one_side.stl', 'shift_one_side');
@@ -6,24 +5,25 @@ STLLibrary.add('js/ergo/stl/U_side_to_horn.stl', 'U_side_to_horn');
 STLLibrary.add('js/ergo/stl/U_horn_to_horn.stl', 'U_horn_to_horn');
 STLLibrary.add('js/ergo/stl/lamp_head.stl', 'lamp_head');
 
-
 var ERGOJR = {};
 
 // Defs
-ERGOJR.UHornToHornLength = 25.0;
-ERGOJR.ShiftOneSideLength = 30.0;
-ERGOJR.USideToHornLength = OLLO.Spacing/2.0 + OLLO.LayerThickness;
-ERGOJR.ToolDist = OLLO.Spacing/2.0 + 2.0 * OLLO.LayerThickness;
+ERGOJR.UHornToHornLength = 25;
+ERGOJR.ShiftOneSideLength = 30;
+ERGOJR.USideToHornLength = OLLO.Spacing / 2 + OLLO.LayerThickness;
+ERGOJR.ToolDist = OLLO.Spacing / 2 + 2 * OLLO.LayerThickness;
 
 //materials
 ERGOJR.printedPartsColor = 0x1975FF;
-ERGOJR.PrintedPartsMaterial = new THREE.MeshLambertMaterial( { color: ERGOJR.printedPartsColor } );
+ERGOJR.PrintedPartsMaterial = new THREE.MeshLambertMaterial({
+  color: ERGOJR.printedPartsColor
+});
 
-// Base - Base + M1
+// Base - Base + m1
 ERGOJR.BaseSegment = function() {
   THREE.Object3D.call(this);
 
-  this.base = new THREE.Mesh( STLLibrary.geometry['base'], ERGOJR.PrintedPartsMaterial);
+  this.base = new THREE.Mesh(STLLibrary.geometry['base'], ERGOJR.PrintedPartsMaterial);
   this.add(this.base);
 
   this.xl320 = new XL320.Object3D();
@@ -36,9 +36,9 @@ ERGOJR.BaseSegment.prototype.constructor = ERGOJR.BaseSegment;
 ERGOJR.Segment1 = function() {
   THREE.Object3D.call(this);
 
-  this.part = new THREE.Mesh( STLLibrary.geometry['U_horn_to_horn'], ERGOJR.PrintedPartsMaterial);
-  this.part.rotation.x = -Math.PI/2;
-  this.part.rotation.y = -Math.PI/2;
+  this.part = new THREE.Mesh(STLLibrary.geometry['U_horn_to_horn'], ERGOJR.PrintedPartsMaterial);
+  this.part.rotation.x = -Math.PI / 2;
+  this.part.rotation.y = -Math.PI / 2;
   this.part.position.z = ERGOJR.UHornToHornLength;
   this.add(this.part);
 };
@@ -50,12 +50,12 @@ ERGOJR.SideToSide = function() {
   THREE.Object3D.call(this);
 
   this.left = new THREE.Mesh( STLLibrary.geometry['shift_one_side'], ERGOJR.PrintedPartsMaterial);
-  this.left.position.z = - XL320.MotorWidth/2.0 - OLLO.LayerThickness/2.0;
+  this.left.position.z = - XL320.MotorWidth / 2 - OLLO.LayerThickness / 2;
   this.add(this.left);
 
   this.right = new THREE.Mesh( STLLibrary.geometry['shift_one_side'], ERGOJR.PrintedPartsMaterial);
   this.right.rotation.y = Math.PI;
-  this.right.position.z = XL320.MotorWidth/2.0 + OLLO.LayerThickness/2.0;
+  this.right.position.z = XL320.MotorWidth / 2 + OLLO.LayerThickness / 2;
   this.add(this.right);
 };
 ERGOJR.SideToSide.prototype = Object.create(THREE.Object3D.prototype);
@@ -70,10 +70,10 @@ ERGOJR.Segment2 = function() {
 
   this.part = new ERGOJR.SideToSide();
   this.part.rotation.z = Math.PI;
-  this.part.position.y = - XL320.MotorLength + XL320.MotorAxisOffset + OLLO.Spacing/2.0;
+  this.part.position.y = - XL320.MotorLength + XL320.MotorAxisOffset + OLLO.Spacing / 2;
   this.add(this.part);
-
 };
+
 ERGOJR.Segment2.prototype = Object.create(THREE.Object3D.prototype);
 ERGOJR.Segment2.prototype.constructor = ERGOJR.Segment2;
 
@@ -86,8 +86,8 @@ ERGOJR.Segment3 = function() {
 
   this.part = new THREE.Mesh( STLLibrary.geometry['U_side_to_horn'], ERGOJR.PrintedPartsMaterial);
   this.part.rotation.x = Math.PI;
-  this.part.rotation.y = Math.PI/2.0;
-  this.part.position.y = -XL320.MotorLength + XL320.MotorAxisOffset+ OLLO.Spacing/2.0;
+  this.part.rotation.y = Math.PI / 2;
+  this.part.position.y = - XL320.MotorLength + XL320.MotorAxisOffset + OLLO.Spacing / 2;
   this.add(this.part);
 };
 ERGOJR.Segment3.prototype = Object.create(THREE.Object3D.prototype);
@@ -102,8 +102,8 @@ ERGOJR.Segment4 = function() {
 
   this.part = new ERGOJR.SideToSide();
   this.part.rotation.x = Math.PI;
-  this.part.rotation.y = Math.PI/2.0;
-  this.part.position.y = - 3.0 * OLLO.Spacing;
+  this.part.rotation.y = Math.PI / 2;
+  this.part.position.y = - 3 * OLLO.Spacing;
   this.add(this.part);
 };
 ERGOJR.Segment4.prototype = Object.create(THREE.Object3D.prototype);
@@ -118,7 +118,7 @@ ERGOJR.Segment5 = function() {
 
   this.part = new ERGOJR.SideToSide();
   this.part.rotation.x = Math.PI;
-  this.part.position.y = - 4.0 * OLLO.Spacing;
+  this.part.position.y = - 4 * OLLO.Spacing;
   this.add(this.part);
 };
 ERGOJR.Segment5.prototype = Object.create(THREE.Object3D.prototype);
@@ -133,8 +133,8 @@ ERGOJR.Segment6 = function() {
 
   this.part = new THREE.Mesh( STLLibrary.geometry['lamp_head'], ERGOJR.PrintedPartsMaterial);
   this.part.rotation.x = Math.PI;
-  this.part.rotation.y = Math.PI/2.0;
-  this.part.position.y = - 4.0 * OLLO.Spacing;
+  this.part.rotation.y = Math.PI / 2;
+  this.part.position.y = - 4 * OLLO.Spacing;
   this.add(this.part);
 };
 
@@ -146,31 +146,31 @@ ERGOJR.Robot = function() {
   THREE.Object3D.call(this);
 
   this.S6 = new ERGOJR.Segment6();
-  this.S6.position.y = - 4.0*OLLO.Spacing - ERGOJR.ShiftOneSideLength;
+  this.S6.position.y = - 4 * OLLO.Spacing - ERGOJR.ShiftOneSideLength;
 
   this.S5 = new ERGOJR.Segment5();
-  this.S5.rotation.y = -Math.PI/2.0;
-  this.S5.position.y = - 3.0*OLLO.Spacing - ERGOJR.ShiftOneSideLength;
+  this.S5.rotation.y = -Math.PI / 2;
+  this.S5.position.y = - 3 * OLLO.Spacing - ERGOJR.ShiftOneSideLength;
 
   this.S4 = new ERGOJR.Segment4();
-  this.S4.rotation.x = -Math.PI/2.0;
-  this.S4.rotation.z = Math.PI/2.0;
-  this.S4.position.y = - XL320.MotorLength + XL320.MotorAxisOffset - XL320.MotorHeight/2.0 - ERGOJR.USideToHornLength ;
+  this.S4.rotation.x = -Math.PI / 2;
+  this.S4.rotation.z = Math.PI / 2;
+  this.S4.position.y = - XL320.MotorLength + XL320.MotorAxisOffset - XL320.MotorHeight / 2 - ERGOJR.USideToHornLength ;
 
   this.S3 = new ERGOJR.Segment3();
-  this.S3.position.y = - XL320.MotorLength + XL320.MotorAxisOffset + OLLO.Spacing/2.0 - ERGOJR.ShiftOneSideLength;
+  this.S3.position.y = - XL320.MotorLength + XL320.MotorAxisOffset + OLLO.Spacing / 2 - ERGOJR.ShiftOneSideLength;
 
   this.S2 = new ERGOJR.Segment2();
-  this.S2.rotation.x = -Math.PI/2.0;
-  this.S2.rotation.y = -Math.PI/2.0;
+  this.S2.rotation.x = -Math.PI / 2;
+  this.S2.rotation.y = -Math.PI / 2;
   this.S2.position.z = ERGOJR.UHornToHornLength;
 
   this.S1 = new ERGOJR.Segment1();
-  this.S1.position.z = XL320.MotorHeight/2.0 + OLLO.LayerThickness;
+  this.S1.position.z = XL320.MotorHeight / 2 + OLLO.LayerThickness;
 
   this.S0 = new ERGOJR.BaseSegment();
-  this.S0.rotation.x = -Math.PI/2.0;
-  this.S0.position.y = XL320.MotorHeight/2.0 + OLLO.LayerThickness;
+  this.S0.rotation.x = -Math.PI / 2;
+  this.S0.position.y = XL320.MotorHeight / 2 + OLLO.LayerThickness;
 
   // builiding the robot
   this.S5.add(this.S6);

--- a/simulator/js/ergo/ollo.js
+++ b/simulator/js/ergo/ollo.js
@@ -1,4 +1,3 @@
-
 var OLLO = {};
 
 // Diameter of the body of Ollo Rivet

--- a/simulator/js/main.js
+++ b/simulator/js/main.js
@@ -1,11 +1,12 @@
 // Start the app
-require( ['detector', 'app', 'container'], function ( Detector, app, container ) {
-  if ( ! Detector.webgl ) {
+require([ 'detector', 'app', 'container' ], function(Detector, app, container) {
+
+  if (!Detector.webgl) {
     Detector.addGetWebGLMessage();
-    container.innerHTML = "";
+    container.innerHTML = '';
   }
 
   // Initialize our app and start the animation loop (animate is expected to call itself)
   app.init();
   app.animate();
-} );
+});


### PR DESCRIPTION
This PR brings a couple of enhancements for the Poppy Ergo Jr web viewer.

One optimisation was done to improve code consistency, code now follows more or less [Google javascript code conventions](https://google.github.io/styleguide/javascriptguide.xml).
This could – and should — should be ran against JSLint/JSHint/JSCS/<insert your weapon of choice here> to ensure code consistency through all pull requests.

Another optimisation was to batch API calls to avoid cancelled xhr requests due to fast refresh rates. It should save some browser resources and make execution more stable.
This comes in addition to [extending Pypot HTTP API](https://github.com/poppy-project/pypot/commit/39262a8789d4138a1f65222f8b4f6d393ad07528).

Finally, `.gitignore` file was updated to ignore only `lib` folder at project's root level..