### PR TITLE
Add tornado as a required dependancy (used in HttpRemoteServer)

### DIFF
--- a/software/conda.recipe/meta.yaml
+++ b/software/conda.recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
     - pypot >2.11
     - poppy-creature >=1.8
     - tornado
+    - bottle
+
 
   run:
     - python
@@ -26,6 +28,7 @@ requirements:
     - opencv3
     - hampy
     - tornado
+    - bottle
 
 test:
 

--- a/software/conda.recipe/meta.yaml
+++ b/software/conda.recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - setuptools
     - pypot >2.11
     - poppy-creature >=1.8
+    - tornado
 
   run:
     - python
@@ -24,6 +25,7 @@ requirements:
     - poppy-creature >=1.8
     - opencv3
     - hampy
+    - tornado
 
 test:
 

--- a/software/setup.py
+++ b/software/setup.py
@@ -18,7 +18,7 @@ setup(name='poppy-ergo-jr',
       version=version(),
       packages=find_packages(),
 
-      install_requires=['pypot >= 2.11', 'poppy-creature >= 1.8', 'hampy'],
+      install_requires=['pypot[http-server] >= 2.11', 'poppy-creature >= 1.8', 'hampy', 'tornado', 'bottle'],
 
       include_package_data=True,
       exclude_package_data={'': ['README', '.gitignore']},


### PR DESCRIPTION
For an unknown raison, http-server key of pypot (pypot[http-server]) have been deleted of the requirements of popy-creature.
However, for a very odd raison I didn't manage to install tornado with a `pip install pypot[http-server]`, so I added it in the requirements.
Any comments @pierre-rouanet ?